### PR TITLE
Fix IndexOutOfBoundsException on tag creation

### DIFF
--- a/src/main/java/com/lkeehl/tagapi/TagListener.java
+++ b/src/main/java/com/lkeehl/tagapi/TagListener.java
@@ -216,7 +216,7 @@ public class TagListener implements Listener {
 
         entity.setMetadata("had-default-tag", new FixedMetadataValue(TagAPI.getPlugin(), true));
         TagAPI.entityDefaultTags.get(entity.getType()).apply(entity).giveTag();
-        initiatingEntitiesToIgnore.remove(entityID);
+        initiatingEntitiesToIgnore.remove(Integer.valueOf(entityID));
     }
 
     public void setupTask() {


### PR DESCRIPTION
Fix the error below

```[00:34:05 WARN]: [TagAPI] Task #1809 for TagAPI v1.2.1 generated an exception
java.lang.IndexOutOfBoundsException: Index 135 out of bounds for length 60
        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
        at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266) ~[?:?]
        at java.util.Objects.checkIndex(Objects.java:359) ~[?:?]
        at java.util.ArrayList.remove(ArrayList.java:504) ~[?:?]
        at com.lkeehl.tagapi.TagListener.createTagForSpawnedEntity(TagListener.java:219) ~[TagAPI.jar:?]
        at com.lkeehl.tagapi.TagListener$1.lambda$onPacketSending$0(TagListener.java:74) ~[TagAPI.jar:?]
        at org.bukkit.craftbukkit.v1_18_R2.scheduler.CraftTask.run(CraftTask.java:101) ~[paper-1.18.2.jar:git-Paper-283]
        at org.bukkit.craftbukkit.v1_18_R2.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:483) ~[paper-1.18.2.jar:git-Paper-283]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1531) ~[paper-1.18.2.jar:git-Paper-283]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:483) ~[paper-1.18.2.jar:git-Paper-283]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1455) ~[paper-1.18.2.jar:git-Paper-283]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1225) ~[paper-1.18.2.jar:git-Paper-283]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:315) ~[paper-1.18.2.jar:git-Paper-283]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]```